### PR TITLE
fix: AuthenticationMD5Password AuthType

### DIFF
--- a/authentication_md5_password.go
+++ b/authentication_md5_password.go
@@ -37,7 +37,7 @@ func (dst *AuthenticationMD5Password) Decode(src []byte) error {
 func (src *AuthenticationMD5Password) Encode(dst []byte) []byte {
 	dst = append(dst, 'R')
 	dst = pgio.AppendInt32(dst, 12)
-	dst = pgio.AppendUint32(dst, AuthTypeOk)
+	dst = pgio.AppendUint32(dst, AuthTypeMD5Password)
 	dst = append(dst, src.Salt[:]...)
 	return dst
 }


### PR DESCRIPTION
I just finished upgrading my PostgreSQL proxy based on pgproto3, and this was the only problem I encountered.

Thank you so much for all the work you put into pgx and pgproto3, they are truly amazing contributions to the Go and PostgreSQL ecosystem.