### PR TITLE
Add missing GSSEncRequest

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -19,6 +19,7 @@ type Backend struct {
 	describe        Describe
 	execute         Execute
 	flush           Flush
+	gssEncRequest   GSSEncRequest
 	parse           Parse
 	passwordMessage PasswordMessage
 	query           Query
@@ -45,7 +46,7 @@ func (b *Backend) Send(msg BackendMessage) error {
 
 // ReceiveStartupMessage receives the initial connection message. This method is used of the normal Receive method
 // because the initial connection message is "special" and does not include the message type as the first byte. This
-// will return either a StartupMessage, SSLRequest, or CancelRequest.
+// will return either a StartupMessage, SSLRequest, GSSEncRequest, or CancelRequest.
 func (b *Backend) ReceiveStartupMessage() (FrontendMessage, error) {
 	buf, err := b.cr.Next(4)
 	if err != nil {
@@ -79,6 +80,12 @@ func (b *Backend) ReceiveStartupMessage() (FrontendMessage, error) {
 			return nil, err
 		}
 		return &b.cancelRequest, nil
+	case gssEncReqNumber:
+		err = b.gssEncRequest.Decode(buf)
+		if err != nil {
+			return nil, err
+		}
+		return &b.gssEncRequest, nil
 	default:
 		return nil, fmt.Errorf("unknown startup message code: %d", code)
 	}

--- a/gss_enc_request.go
+++ b/gss_enc_request.go
@@ -1,0 +1,49 @@
+package pgproto3
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+
+	"github.com/jackc/pgio"
+)
+
+const gssEncReqNumber = 80877104
+
+type GSSEncRequest struct {
+}
+
+// Frontend identifies this message as sendable by a PostgreSQL frontend.
+func (*GSSEncRequest) Frontend() {}
+
+func (dst *GSSEncRequest) Decode(src []byte) error {
+	if len(src) < 4 {
+		return errors.New("gss encoding request too short")
+	}
+
+	requestCode := binary.BigEndian.Uint32(src)
+
+	if requestCode != gssEncReqNumber {
+		return errors.New("bad gss encoding request code")
+	}
+
+	return nil
+}
+
+// Encode encodes src into dst. dst will include the 4 byte message length.
+func (src *GSSEncRequest) Encode(dst []byte) []byte {
+	dst = pgio.AppendInt32(dst, 8)
+	dst = pgio.AppendInt32(dst, gssEncReqNumber)
+	return dst
+}
+
+// MarshalJSON implements encoding/json.Marshaler.
+func (src GSSEncRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type            string
+		ProtocolVersion uint32
+		Parameters      map[string]string
+	}{
+		Type: "GSSEncRequest",
+	})
+}


### PR DESCRIPTION
This patch adds the missing `GSSEncRequest` which is described in the FE protocol as:

```
GSSENCRequest (F)

    Int32(8)

        Length of message contents in bytes, including self.
    Int32(80877104)

        The GSSAPI Encryption request code. The value is chosen to contain 1234 in the most significant 16 bits, and 5680 in the least significant 16 bits. (To avoid confusion, this code must not be the same as any protocol version number.)
```

The documentation also states, 

> To initiate a GSSAPI-encrypted connection, the frontend initially sends a GSSENCRequest message rather than a StartupMessage.

This patch provides the missing request.