### PR TITLE
Add support for identifying authentication messages

### DIFF
--- a/authentication_cleartext_password.go
+++ b/authentication_cleartext_password.go
@@ -15,6 +15,9 @@ type AuthenticationCleartextPassword struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationCleartextPassword) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationCleartextPassword) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationCleartextPassword) Decode(src []byte) error {

--- a/authentication_md5_password.go
+++ b/authentication_md5_password.go
@@ -16,6 +16,9 @@ type AuthenticationMD5Password struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationMD5Password) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationMD5Password) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationMD5Password) Decode(src []byte) error {

--- a/authentication_ok.go
+++ b/authentication_ok.go
@@ -15,6 +15,9 @@ type AuthenticationOk struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationOk) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationOk) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationOk) Decode(src []byte) error {

--- a/authentication_sasl.go
+++ b/authentication_sasl.go
@@ -17,6 +17,9 @@ type AuthenticationSASL struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationSASL) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationSASL) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationSASL) Decode(src []byte) error {

--- a/authentication_sasl_continue.go
+++ b/authentication_sasl_continue.go
@@ -16,6 +16,9 @@ type AuthenticationSASLContinue struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationSASLContinue) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationSASLContinue) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationSASLContinue) Decode(src []byte) error {

--- a/authentication_sasl_final.go
+++ b/authentication_sasl_final.go
@@ -16,6 +16,9 @@ type AuthenticationSASLFinal struct {
 // Backend identifies this message as sendable by the PostgreSQL backend.
 func (*AuthenticationSASLFinal) Backend() {}
 
+// Backend identifies this message as an authentication response.
+func (*AuthenticationSASLFinal) AuthenticationResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *AuthenticationSASLFinal) Decode(src []byte) error {

--- a/password_message.go
+++ b/password_message.go
@@ -14,6 +14,9 @@ type PasswordMessage struct {
 // Frontend identifies this message as sendable by a PostgreSQL frontend.
 func (*PasswordMessage) Frontend() {}
 
+// Frontend identifies this message as an authentication response.
+func (*PasswordMessage) InitialResponse() {}
+
 // Decode decodes src into dst. src must contain the complete message with the exception of the initial 1 byte message
 // type identifier and 4 byte message length.
 func (dst *PasswordMessage) Decode(src []byte) error {

--- a/pgproto3.go
+++ b/pgproto3.go
@@ -27,6 +27,11 @@ type BackendMessage interface {
 	Backend() // no-op method to distinguish frontend from backend methods
 }
 
+type AuthenticationResponseMessage interface {
+	BackendMessage
+	AuthenticationResponse() // no-op method to distinguish authentication responses
+}
+
 type invalidMessageLenErr struct {
 	messageType string
 	expectedLen int


### PR DESCRIPTION
The pgprotocol overloads 'p' messages with PasswordMessage,
SASLInitialResponse, SASLResponse, and GSSResponse. This patch allows
contextual identification of the message by setting the authType in the
frontend and then setting this value in the backend when a
AuthenticationResponseMessage is received. An example of usage is
provided in example/authident/authident.go.