### PR TITLE
Fix JSON output for SASL{Response,InitialResponse}

### DIFF
--- a/sasl_initial_response.go
+++ b/sasl_initial_response.go
@@ -64,7 +64,7 @@ func (src SASLInitialResponse) MarshalJSON() ([]byte, error) {
 	}{
 		Type:          "SASLInitialResponse",
 		AuthMechanism: src.AuthMechanism,
-		Data:          hex.EncodeToString(src.Data),
+		Data:          string(src.Data),
 	})
 }
 

--- a/sasl_response.go
+++ b/sasl_response.go
@@ -38,7 +38,7 @@ func (src SASLResponse) MarshalJSON() ([]byte, error) {
 		Data string
 	}{
 		Type: "SASLResponse",
-		Data: hex.EncodeToString(src.Data),
+		Data: string(src.Data),
 	})
 }
 


### PR DESCRIPTION
Hex encoding the Data field in the SASL responses made debugging SCRAM
more difficult than actually helping.

Before:

F{"Type":"SASLResponse","Data":"633d655377732c723d4d4d4e4e6d666b536f5862694a68385833466d324f2b4d77787354692f4550753052414157484b7a306b7376336c5747392f4d4a5267504d2c703d616742664b533164383937674b4f4a6d4c7171626c49326b6b4a506f2b58354359516c63473458357657343d"}
F{"Type":"SASLInitialResponse","AuthMechanism":"SCRAM-SHA-256","Data":"792c2c6e3d2c723d4d4d4e4e6d666b536f5862694a68385833466d324f2b4d77"}

After:

F{"Type":"SASLResponse","Data":"c=eSws,r=9dR43UQLL1KbrKKl4/QbxjqgVjZYR9mqnx3rFBiI7R/1pp5oeVYMGhXj,p=b2hmuvTvWn2xN0fclm+O4TwLAarRM8xoHSN7jsKDHAU="}
F{"Type":"SASLInitialResponse","AuthMechanism":"SCRAM-SHA-256","Data":"y,,n=,r=9dR43UQLL1KbrKKl4/Qbxjqg"}