### PR TITLE
Don't panic when receiving zero bytes with "slice bounds out of range"

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,7 @@ package pgproto3
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -114,6 +115,9 @@ func (b *Backend) Receive() (FrontendMessage, error) {
 		b.msgType = header[0]
 		b.bodyLen = int(binary.BigEndian.Uint32(header[1:])) - 4
 		b.partialMsg = true
+		if b.bodyLen < 0 {
+			return nil, errors.New("invalid message with negative body length received")
+		}
 	}
 
 	var msg FrontendMessage

--- a/frontend.go
+++ b/frontend.go
@@ -79,6 +79,9 @@ func (f *Frontend) Receive() (BackendMessage, error) {
 		f.msgType = header[0]
 		f.bodyLen = int(binary.BigEndian.Uint32(header[1:])) - 4
 		f.partialMsg = true
+		if f.bodyLen < 0 {
+			return nil, errors.New("invalid message with negative body length received")
+		}
 	}
 
 	msgBody, err := f.cr.Next(f.bodyLen)


### PR DESCRIPTION
Hi, this is related to https://github.com/jackc/pgx/issues/1155 - we still haven't found the root cause of that problem. By this change we plan to at least prevent panic in this case i.e. when message length decodes to a value smaller than 4. I think it should be a good change anyway, so I'm submitting it as a PR :-)