### PR TITLE
SASLResponse/SASLInitialResponse UnmarshalJSON: removing hex decode

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -489,10 +489,10 @@ func TestJSONUnmarshalQuery(t *testing.T) {
 }
 
 func TestJSONUnmarshalSASLInitialResponse(t *testing.T) {
-	data := []byte(`{"Type":"SASLInitialResponse", "AuthMechanism":"SCRAM-SHA-256", "Data": "6D"}`)
+	data := []byte(`{"Type":"SASLInitialResponse", "AuthMechanism":"SCRAM-SHA-256", "Data": "abc"}`)
 	want := SASLInitialResponse{
 		AuthMechanism: "SCRAM-SHA-256",
-		Data:          []byte{109},
+		Data:          []byte("abc"),
 	}
 
 	var got SASLInitialResponse
@@ -505,8 +505,10 @@ func TestJSONUnmarshalSASLInitialResponse(t *testing.T) {
 }
 
 func TestJSONUnmarshalSASLResponse(t *testing.T) {
-	data := []byte(`{"Type":"SASLResponse","Message":"abc"}`)
-	want := SASLResponse{}
+	data := []byte(`{"Type":"SASLResponse","Data":"abc"}`)
+	want := SASLResponse{
+		Data: []byte("abc"),
+	}
 
 	var got SASLResponse
 	if err := json.Unmarshal(data, &got); err != nil {

--- a/sasl_initial_response.go
+++ b/sasl_initial_response.go
@@ -2,7 +2,6 @@ package pgproto3
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 
@@ -83,12 +82,6 @@ func (dst *SASLInitialResponse) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	dst.AuthMechanism = msg.AuthMechanism
-	if msg.Data != "" {
-		decoded, err := hex.DecodeString(msg.Data)
-		if err != nil {
-			return err
-		}
-		dst.Data = decoded
-	}
+	dst.Data = []byte(msg.Data)
 	return nil
 }

--- a/sasl_response.go
+++ b/sasl_response.go
@@ -1,7 +1,6 @@
 package pgproto3
 
 import (
-	"encoding/hex"
 	"encoding/json"
 
 	"github.com/jackc/pgio"
@@ -50,12 +49,6 @@ func (dst *SASLResponse) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &msg); err != nil {
 		return err
 	}
-	if msg.Data != "" {
-		decoded, err := hex.DecodeString(msg.Data)
-		if err != nil {
-			return err
-		}
-		dst.Data = decoded
-	}
+	dst.Data = []byte(msg.Data)
 	return nil
 }


### PR DESCRIPTION
PR #22 removed hex encoding from SASLResponse/SASLInitialResponse when marshalling to JSON. 
This PR removes the hex decoding when unmarshalling, to allow round tripping.